### PR TITLE
v3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ var expressVue = require('express-vue');
 
 var app = express();
 app.set('views', __dirname + '/app/views');
+//Optional if you want to specify the components directory seperate to your views, and/or specify a custom layout.
 app.set('vue', {
     //ComponentsDir is optional if you are storing your components in a different directory than your views
     componentsDir: __dirname + '/components',

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ $ npm install --save express-vue
 var expressVue = require('express-vue');
 
 var app = express();
-app.set('views', 'PATH_TO_VIEWS/routes');
+app.set('views', __dirname + '/app/views');
 app.set('vue', {
-    rootPath: __dirname + '/',
-    layoutsDir: 'app/components/',
-    componentsDir: 'components/',
+    //ComponentsDir is optional if you are storing your components in a different directory than your views
+    componentsDir: __dirname + '/components',
+    //Default layout is optional it's a file and relative to the views path, it does not require a .vue extention.
+    //If you want a custom layout set this to the location of your layout.vue file.
     defaultLayout: 'layout'
 });
 app.engine('vue', expressVue);
@@ -152,7 +153,9 @@ A full example can be found at: [danmademe/express-vue-example](https://github.c
 
 Requires Node V4 or greater
 
-It requires you to have a file called layout.vue file similar to this in the `app/components/` directory
+## Optional
+
+If you want to have a custom layout you can, here is an example layout.vue file which you can place relative to your views path.
 
 It's required to set the `{{{app}}}` and `{{{script}}}` tags where you want the layout body and script to go.
 If you want to set a title or other meta data, you can add them to the vue metadata object, you can look at the above

--- a/dist/defaults.js
+++ b/dist/defaults.js
@@ -22,7 +22,7 @@ var Defaults = function Defaults() {
 
     this.rootPath = obj.rootPath === undefined ? viewsPath + '/' : obj.rootPath + '/';
     this.layoutsDir = obj.layoutsDir === undefined ? '' : this.rootPath + obj.layoutsDir + '/';
-    this.componentsDir = obj.componentsDir === undefined ? '' : this.rootPath + obj.componentsDir + '/';
+    this.componentsDir = obj.componentsDir === undefined ? '' : obj.componentsDir + '/';
     this.defaultLayout = obj.defaultLayout === undefined ? '' : obj.layoutsDir === undefined ? this.rootPath + obj.defaultLayout : obj.defaultLayout;
     this.options = obj.options === undefined ? '' : obj.options;
     this.backupLayout = '<template><!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><script src="https://unpkg.com/vue/dist/vue.js"></script></head><body>{{{app}}}{{{script}}}<script>app.$mount("#app")</script></body></html></template><script></script><style></style>';

--- a/dist/defaults.js
+++ b/dist/defaults.js
@@ -26,7 +26,6 @@ var Defaults = function Defaults() {
     this.defaultLayout = obj.defaultLayout === undefined ? '' : obj.layoutsDir === undefined ? this.rootPath + obj.defaultLayout : obj.defaultLayout;
     this.options = obj.options === undefined ? '' : obj.options;
     this.backupLayout = '<template><!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><script src="https://unpkg.com/vue/dist/vue.js"></script></head><body>{{{app}}}{{{script}}}<script>app.$mount("#app")</script></body></html></template><script></script><style></style>';
-    console.log(this);
 };
 
 exports.Types = Types;

--- a/dist/defaults.js
+++ b/dist/defaults.js
@@ -16,14 +16,17 @@ var Types = function Types() {
 
 var Defaults = function Defaults() {
     var obj = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var viewsPath = arguments[1];
 
     _classCallCheck(this, Defaults);
 
-    this.rootPath = obj.rootPath || '';
-    this.layoutsDir = this.rootPath + obj.layoutsDir || '/app/routes/';
-    this.componentsDir = this.rootPath + obj.componentsDir || '/app/components/';
-    this.defaultLayout = obj.defaultLayout || 'layout';
-    this.options = obj.options || undefined;
+    this.rootPath = obj.rootPath === undefined ? viewsPath + '/' : obj.rootPath + '/';
+    this.layoutsDir = obj.layoutsDir === undefined ? '' : this.rootPath + obj.layoutsDir + '/';
+    this.componentsDir = obj.componentsDir === undefined ? '' : this.rootPath + obj.componentsDir + '/';
+    this.defaultLayout = obj.defaultLayout === undefined ? '' : obj.layoutsDir === undefined ? this.rootPath + obj.defaultLayout : obj.defaultLayout;
+    this.options = obj.options === undefined ? '' : obj.options;
+    this.backupLayout = '<template><!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><script src="https://unpkg.com/vue/dist/vue.js"></script></head><body>{{{app}}}{{{script}}}<script>app.$mount("#app")</script></body></html></template><script></script><style></style>';
+    console.log(this);
 };
 
 exports.Types = Types;

--- a/dist/index.js
+++ b/dist/index.js
@@ -12,7 +12,7 @@ var _utils = require('./utils');
 
 function expressVue(componentPath, options, callback) {
 
-    var defaults = new _defaults.Defaults(options.settings.vue);
+    var defaults = new _defaults.Defaults(options.settings.vue, options.settings.views);
     var types = new _defaults.Types();
     defaults.layoutPath = defaults.layoutsDir + defaults.defaultLayout + '.vue';
     defaults.options = options;

--- a/dist/parser/index.js
+++ b/dist/parser/index.js
@@ -24,8 +24,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var htmlMinifier = _htmlMinifier2.default.minify;
-var htmlRegex = /(<template?.*>)([\s\S]*?)(<\/template>)/gm;
-var scriptRegex = /(<script?.*>)([\s\S]*?)(<\/script>)/gm;
+var htmlRegex = /(<template.*?>)([\s\S]*?)(<\/template>)/gm;
+var scriptRegex = /(<script.*?>)([\s\S]*?)(<\/script>)/gm;
 var types = new _defaults.Types();
 
 function htmlParser(body, minify) {
@@ -91,9 +91,9 @@ function layoutParser(layoutPath, defaults, type) {
     return new Promise(function (resolve, reject) {
         _fs2.default.readFile(layoutPath, 'utf-8', function (err, content) {
             if (err) {
-                reject(new Error(err));
+                content = defaults.backupLayout;
             }
-
+            console.log(layoutPath);
             var body = htmlParser(content);
             content = content.replace(htmlRegex, '');
             var script = scriptParser(content, defaults, type);
@@ -113,7 +113,7 @@ function componentParser(templatePath, defaults, type) {
             if (err) {
                 reject(new Error(err));
             }
-
+            console.log(templatePath);
             var body = htmlParser(content, true);
             content = content.replace(htmlRegex, '');
             var script = scriptParser(content, defaults, type);

--- a/dist/parser/index.js
+++ b/dist/parser/index.js
@@ -88,12 +88,12 @@ function scriptParser(script, defaults, type) {
 }
 
 function layoutParser(layoutPath, defaults, type) {
-    return new Promise(function (resolve, reject) {
+    return new Promise(function (resolve) {
         _fs2.default.readFile(layoutPath, 'utf-8', function (err, content) {
             if (err) {
                 content = defaults.backupLayout;
             }
-            console.log(layoutPath);
+
             var body = htmlParser(content);
             content = content.replace(htmlRegex, '');
             var script = scriptParser(content, defaults, type);
@@ -113,7 +113,7 @@ function componentParser(templatePath, defaults, type) {
             if (err) {
                 reject(new Error(err));
             }
-            console.log(templatePath);
+
             var body = htmlParser(content, true);
             content = content.replace(htmlRegex, '');
             var script = scriptParser(content, defaults, type);

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -9,7 +9,7 @@ class Defaults {
     constructor(obj = {}, viewsPath) {
         this.rootPath      = obj.rootPath      === undefined ? viewsPath + '/' : obj.rootPath + '/';
         this.layoutsDir    = obj.layoutsDir    === undefined ? '' : this.rootPath + obj.layoutsDir + '/';
-        this.componentsDir = obj.componentsDir === undefined ? '' : this.rootPath + obj.componentsDir + '/';
+        this.componentsDir = obj.componentsDir === undefined ? '' : obj.componentsDir + '/';
         this.defaultLayout = obj.defaultLayout === undefined ? '' : obj.layoutsDir === undefined ? this.rootPath + obj.defaultLayout : obj.defaultLayout;
         this.options       = obj.options       === undefined ? '' : obj.options;
         this.backupLayout  = '<template><!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><script src="https://unpkg.com/vue/dist/vue.js"></script></head><body>{{{app}}}{{{script}}}<script>app.$mount("#app")</script></body></html></template><script></script><style></style>';

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -6,12 +6,13 @@ class Types {
     }
 }
 class Defaults {
-    constructor(obj = {}) {
-        this.rootPath      = obj.rootPath || '';
-        this.layoutsDir    = this.rootPath + obj.layoutsDir || '/app/routes/';
-        this.componentsDir = this.rootPath + obj.componentsDir || '/app/components/';
-        this.defaultLayout = obj.defaultLayout || 'layout';
-        this.options       = obj.options || undefined;
+    constructor(obj = {}, viewsPath) {
+        this.rootPath      = obj.rootPath      === undefined ? viewsPath + '/' : obj.rootPath + '/';
+        this.layoutsDir    = obj.layoutsDir    === undefined ? '' : this.rootPath + obj.layoutsDir + '/';
+        this.componentsDir = obj.componentsDir === undefined ? '' : this.rootPath + obj.componentsDir + '/';
+        this.defaultLayout = obj.defaultLayout === undefined ? '' : obj.layoutsDir === undefined ? this.rootPath + obj.defaultLayout : obj.defaultLayout;
+        this.options       = obj.options       === undefined ? '' : obj.options;
+        this.backupLayout  = '<template><!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><script src="https://unpkg.com/vue/dist/vue.js"></script></head><body>{{{app}}}{{{script}}}<script>app.$mount("#app")</script></body></html></template><script></script><style></style>';
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ import {renderHtmlUtil} from './utils';
 
 function expressVue(componentPath, options, callback) {
 
-    let defaults = new Defaults(options.settings.vue);
+    let defaults = new Defaults(options.settings.vue, options.settings.views);
     let types    = new Types();
     defaults.layoutPath = defaults.layoutsDir + defaults.defaultLayout + '.vue';
     defaults.options = options;

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -4,8 +4,8 @@ import {Types} from '../defaults';
 import requireFromString from 'require-from-string';
 
 const htmlMinifier = minify.minify;
-const htmlRegex    = /(<template?.*>)([\s\S]*?)(<\/template>)/gm;
-const scriptRegex  = /(<script?.*>)([\s\S]*?)(<\/script>)/gm;
+const htmlRegex    = /(<template.*?>)([\s\S]*?)(<\/template>)/gm;
+const scriptRegex  = /(<script.*?>)([\s\S]*?)(<\/script>)/gm;
 const types        = new Types();
 
 function htmlParser(body, minify) {
@@ -66,10 +66,10 @@ function scriptParser(script, defaults, type) {
 }
 
 function layoutParser(layoutPath, defaults, type) {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
         fs.readFile(layoutPath, 'utf-8', function (err, content) {
             if (err) {
-                reject(new Error(err));
+                content = defaults.backupLayout;
             }
 
             const body = htmlParser(content);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-vue",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Vue rendering engine for Express.js",
   "homepage": "https://github.com/danmademe/express-vue",
   "author": {


### PR DESCRIPTION
- Changed the vue config object,
- Added fallbacks
- Removed the need to use rootPath and LayoutsDir

Updated for a minimal and optional setup

```js
var expressVue = require('express-vue');

var app = express();
app.set('views', __dirname + '/app/views');
//Optional if you want to specify the components directory seperate to your views, and/or specify a custom layout.
app.set('vue', {
    //ComponentsDir is optional if you are storing your components in a different directory than your views
    componentsDir: __dirname + '/components',
    //Default layout is optional it's a file and relative to the views path, it does not require a .vue extention.
    //If you want a custom layout set this to the location of your layout.vue file.
    defaultLayout: 'layout'
});
app.engine('vue', expressVue);
app.set('view engine', 'vue');
```