### PR TITLE
basic type declaration for Typescript import

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dist"
   ],
   "main": "dist/index.js",
+  "typings": "types/index.d.ts",
   "keywords": [
     "vue",
     "express",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,3 @@
+import * as expressVue from '../dist/index.js';
+
+export = expressVue;


### PR DESCRIPTION
- Added a basic setup for type declarations for Typescript. Nothing fancy yet but it works on Typescript too.
Since your package is published on NPM, you don’t even need external tools like Typings, as declarations are automatically imported with express-vue. That means all you need is a simple:

  `import expressVue = require('express-vue');` 

  and you are able to use express-vue with Typescript.