### PR TITLE
Tyscript declaration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ Finally you'll need to set the link to your copy of vue.js in the script... (thi
 </style>
 ```
 
+## Typescript support
+
+Typescript declarations are published on NPM, so you don’t need external tools like Typings, as declarations are automatically imported with express-vue. That means all you need is a simple:
+
+```js
+import expressVue = require('express-vue');
+```
+
 ## Todo
 
 - Have the style sections do something!

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,3 @@
-import * as expressVue from './index.js';
+declare function expressVue(componentPath: string, options: Object, callback: Function): void;
 
 export = expressVue;


### PR DESCRIPTION
- Eliminated possible typescript errors. Nothing changes as far as how the import works. Typescript import:

  `import expressVue = require('express-vue');`

- Updated README to inform typescript developers that it is supported.